### PR TITLE
버그 수정

### DIFF
--- a/SnowBot.js
+++ b/SnowBot.js
@@ -31,10 +31,10 @@ client.on('message', message => {
 	}
 
 	else if (message.content.startsWith("!빙수 ")) {
-		let args = message.content.split(" ");
+		let command = message.content.split(" ")[0];
 		let menu = getBingsuMenu();
 		menu.forEach(item => {
-			if (args[1] == item.name) {
+			if (message.content.replace(command, "").trim() == item.name) {
 				let bingSuInfoEmbed = new Discord.MessageEmbed()
 					.setColor('#ddbea9')
 					.setTitle(item.name)


### PR DESCRIPTION
오레오초코몬스터 설빙과 같이 공백이 있는 빙수 이름일 경우 빙수 정보가 나오지 않는 버그 수정